### PR TITLE
Leave channel and clear queue on join error, socket error.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ function executeQuery(sockets, context) {
       }
       socket.conn.onOpen(joinChannel.bind(null, resolve))
       socket.conn.onError(err => {
-        if (chan.conn && (chan.conn.isJoined() || chan.conn.isJoining()) {
+        if (chan.conn && (chan.conn.isJoined() || chan.conn.isJoining())) {
           chan.conn.leave()
         }
         chan.queue = []

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,9 @@ function executeQuery(sockets, context) {
         chan.queue = []
         map(performQuery, queue)
       }).receive('error', err => {
+        chan.conn.leave()
         chan.conn = null
+        chan.queue.pop()
         resolve(err)
       })
     }
@@ -80,7 +82,13 @@ function executeQuery(sockets, context) {
         queue: []
       }
       socket.conn.onOpen(joinChannel.bind(null, resolve))
-      socket.conn.onError(resolve)
+      socket.conn.onError(err => {
+        if (chan.conn && (chan.conn.isJoined() || chan.conn.isJoining()) {
+          chan.conn.leave()
+        }
+        chan.queue = []
+        resolve(err)
+      })
     }
     if (chan.conn && chan.conn.isJoined()) {
       performQuery({context, resolve, reject})


### PR DESCRIPTION
@vic I've been doing some more testing the result of which is that we should be using `leave` when a channel join error or socket error occurs.

Without these lines, I have been getting some errors like:

```
EXCEPTION: tried to join multiple times. 'join' can only be called a single     
    time per channel instance
```

To recreate this error, you can simply start & stop the phoenix server. In the console, you should see the above error. This is the state the channel is in when the error occurs (extract from the debugger):

```
> chan.conn
Channelbindings: Array[3]
joinPush: Push
joinedOnce: true
params: Object
pushBuffer: Array[0]
rejoinTimer: Timer
socket: Socketstate: "joined"
timeout: 10000
topic: "gql:query"
__proto__: Object

> chan.conn.isJoined()
false
> chan.conn.isJoining()
false
```

Also, if the `leave` isn't executed, the client will continuously attempt to rejoin the channel - and keep failing if it is an auth problem.

Additionally, when an error occurs, the channel queue must be cleared, otherwise, these queries will be re-executed again later.