### PR TITLE
Wrapped unsubscribe arg in {subscriptionId: ...}

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ the [Absinthe] library to implement your Elixir GQL server. APW is configured by
 to work out of the box with an [Absinthe backend](#absinthe-backend).
 
 But if need araises, you can supply some advanced options to customize how it works.
-Here's is a commented example of the options that you can set for APW:
+Here's is a commented example of the options that you can set for APW, with
+their respective default values:
 
 
 ```javascript
@@ -72,7 +73,9 @@ createNetworkInterface({
 
     // what to do when unsubscribing
     off: controlChannel => {
-      controlChannel.push('unsubscribe', subscriptionResponse.subscriptionId)
+      controlChannel.push('unsubscribe', {
+        subscriptionId: subscriptionResponse.subscriptionId
+      })
     }
   }),
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,9 @@ export const ABSINTHE_OPTIONS = {
     event: 'subscription:data',
     map: payload => payload.result.data,
     off: controlChannel => {
-      controlChannel.push('unsubscribe', subResponse.subscriptionId)
+      controlChannel.push('unsubscribe', {
+        subscriptionId: subscriptionResponse.subscriptionId
+      })
     },
   })
 }
@@ -124,7 +126,9 @@ For example, if you are using Absinthe backend, this function can be like:
         event: 'subscription:data',
         map: payload => payload.result.data,
         off: controlChannel => {
-          controlChannel.push('unsubscribe', subResponse.subscriptionId)
+          controlChannel.push('unsubscribe', {
+            subscriptionId: subResponse.subscriptionId
+          })
         }
       })
 


### PR DESCRIPTION
A small change I had to make to make unsubscribe work with Absinthe master (see [channel.ex#L52](https://github.com/absinthe-graphql/absinthe_phoenix/blob/master/lib/absinthe/phoenix/channel.ex#L52)).